### PR TITLE
add sync-fork.yml workflow

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,45 @@
+name: Sync Fork with Upstream
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Runs at midnight UTC every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Fetch Upstream Remote
+        run: |
+          git remote add upstream https://github.com/gradle/actions.git
+          git fetch upstream
+
+      - name: Set Git Config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and Push Branch 
+        run: |          
+          git checkout -b weekly-sync-branch-${{ github.run_id }}
+          git merge upstream/main --no-commit
+          git reset -- ./.github
+          git commit -m "Merge upstream:main"
+          git commit --allow-empty -m "Empty commit to open PR"
+          git push --set-upstream origin weekly-sync-branch-${{ github.run_id }}
+
+      - name: Open Pull Request 
+        run: |  
+          gh repo set-default actions/gradle-dependency-submission-action
+          gh pr create -B main -H weekly-sync-branch-${{ github.run_id }} --title 'Sync Fork with Upstream' --body 'Weekly Cron. Created by GitHub Actions.'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Open Pull Request 
         run: |  
-          gh repo set-default actions/gradle-dependency-submission-action
+          gh repo set-default actions/gradle-build-tools-actions
           gh pr create -B main -H weekly-sync-branch-${{ github.run_id }} --title 'Sync Fork with Upstream' --body 'Weekly Cron. Created by GitHub Actions.'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
_Part of work to recreate `actions/gradle-dependency-submission-action` as `actions/gradle-build-tools-actions` to better reflect the 3 actions in this action._

Copying sync-fork.yml

History:
* https://github.com/actions/gradle-dependency-submission-action/pull/3
* https://github.com/actions/gradle-dependency-submission-action/pull/4