### PR TITLE
Add retry logic for dependency graph submission

### DIFF
--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -204,7 +204,8 @@ async function submitDependencyGraphs(dependencyGraphFiles: string[]): Promise<v
 
 function translateErrorMessage(jsonFile: string, error: Error): string {
     const relativeJsonFile = getRelativePathFromWorkspace(jsonFile)
-    const mainWarning = `Dependency submission failed for ${relativeJsonFile}.\n${error.message}`
+    const statusInfo = getErrorStatusText(error)
+    const mainWarning = `Dependency submission failed for ${relativeJsonFile}${statusInfo}.\n${error.message}`
     if (error.message === 'Resource not accessible by integration') {
         return `${mainWarning}
 Please ensure that the 'contents: write' permission is available for the workflow job.
@@ -214,6 +215,9 @@ Note that this permission is never available for a 'pull_request' trigger from a
     return mainWarning
 }
 
+const DEPENDENCY_SUBMISSION_MAX_ATTEMPTS = 3
+const DEPENDENCY_SUBMISSION_BASE_DELAY_MS = 1000
+
 async function submitDependencyGraphFile(jsonFile: string): Promise<void> {
     const octokit = getOctokit()
     const jsonContent = fs.readFileSync(jsonFile, 'utf8')
@@ -221,10 +225,42 @@ async function submitDependencyGraphFile(jsonFile: string): Promise<void> {
     const jsonObject = JSON.parse(jsonContent)
     jsonObject.owner = github.context.repo.owner
     jsonObject.repo = github.context.repo.repo
-    const response = await octokit.request('POST /repos/{owner}/{repo}/dependency-graph/snapshots', jsonObject)
 
-    const relativeJsonFile = getRelativePathFromWorkspace(jsonFile)
-    core.notice(`Submitted ${relativeJsonFile}: ${response.data.message}`)
+    for (let attempt = 1; attempt <= DEPENDENCY_SUBMISSION_MAX_ATTEMPTS; attempt++) {
+        try {
+            const response = await octokit.request('POST /repos/{owner}/{repo}/dependency-graph/snapshots', jsonObject)
+            const relativeJsonFile = getRelativePathFromWorkspace(jsonFile)
+            core.notice(`Submitted ${relativeJsonFile}: ${response.data.message}`)
+            return
+        } catch (error) {
+            if (isRetryableError(error) && attempt < DEPENDENCY_SUBMISSION_MAX_ATTEMPTS) {
+                const delay = DEPENDENCY_SUBMISSION_BASE_DELAY_MS * Math.pow(2, attempt - 1)
+                core.info(
+                    `Dependency submission attempt ${attempt} failed` +
+                        `${getErrorStatusText(error)}. ` +
+                        `Retrying in ${delay}ms...`
+                )
+                await new Promise(resolve => setTimeout(resolve, delay))
+            } else {
+                throw error
+            }
+        }
+    }
+}
+
+export function isRetryableError(error: unknown): boolean {
+    if (error instanceof Error && 'status' in error) {
+        const status = (error as Error & {status: number}).status
+        return status === 429 || status >= 500
+    }
+    return false
+}
+
+export function getErrorStatusText(error: unknown): string {
+    if (error instanceof Error && 'status' in error) {
+        return ` (HTTP ${(error as Error & {status: number}).status})`
+    }
+    return ''
 }
 function getReportDirectory(): string {
     return process.env.DEPENDENCY_GRAPH_REPORT_DIR!

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -248,20 +248,21 @@ async function submitDependencyGraphFile(jsonFile: string): Promise<void> {
     }
 }
 
+function hasHttpStatus(error: unknown): error is Error & {status: number} {
+    return error instanceof Error && 'status' in error && typeof (error as {status: unknown}).status === 'number'
+}
+
 export function isRetryableError(error: unknown): boolean {
-    if (error instanceof Error && 'status' in error) {
-        const status = (error as Error & {status: number}).status
-        return status === 429 || status >= 500
+    if (!hasHttpStatus(error)) {
+        return false
     }
-    return false
+    return error.status >= 500 || error.status === 429 // Too Many Requests
 }
 
 export function getErrorStatusText(error: unknown): string {
-    if (error instanceof Error && 'status' in error) {
-        return ` (HTTP ${(error as Error & {status: number}).status})`
-    }
-    return ''
+    return hasHttpStatus(error) ? ` (HTTP ${error.status})` : ''
 }
+
 function getReportDirectory(): string {
     return process.env.DEPENDENCY_GRAPH_REPORT_DIR!
 }

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -226,26 +226,48 @@ async function submitDependencyGraphFile(jsonFile: string): Promise<void> {
     jsonObject.owner = github.context.repo.owner
     jsonObject.repo = github.context.repo.repo
 
-    for (let attempt = 1; attempt <= DEPENDENCY_SUBMISSION_MAX_ATTEMPTS; attempt++) {
-        try {
-            const response = await octokit.request('POST /repos/{owner}/{repo}/dependency-graph/snapshots', jsonObject)
-            const relativeJsonFile = getRelativePathFromWorkspace(jsonFile)
-            core.notice(`Submitted ${relativeJsonFile}: ${response.data.message}`)
-            return
-        } catch (error) {
-            if (isRetryableError(error) && attempt < DEPENDENCY_SUBMISSION_MAX_ATTEMPTS) {
-                const delay = DEPENDENCY_SUBMISSION_BASE_DELAY_MS * Math.pow(2, attempt - 1)
+    const response = await retryWithBackoff(
+        async () => octokit.request('POST /repos/{owner}/{repo}/dependency-graph/snapshots', jsonObject),
+        {
+            maxAttempts: DEPENDENCY_SUBMISSION_MAX_ATTEMPTS,
+            baseDelayMs: DEPENDENCY_SUBMISSION_BASE_DELAY_MS,
+            isRetryable: isRetryableError,
+            onRetry: (attempt, delayMs, error) => {
                 core.info(
                     `Dependency submission attempt ${attempt} failed` +
                         `${getErrorStatusText(error)}. ` +
-                        `Retrying in ${delay}ms...`
+                        `Retrying in ${delayMs}ms...`
                 )
-                await new Promise(resolve => setTimeout(resolve, delay))
+            }
+        }
+    )
+    const relativeJsonFile = getRelativePathFromWorkspace(jsonFile)
+    core.notice(`Submitted ${relativeJsonFile}: ${response.data.message}`)
+}
+
+export interface RetryOptions {
+    maxAttempts: number
+    baseDelayMs: number
+    isRetryable: (error: unknown) => boolean
+    onRetry?: (attempt: number, delayMs: number, error: unknown) => void
+}
+
+export async function retryWithBackoff<T>(operation: () => Promise<T>, options: RetryOptions): Promise<T> {
+    for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+        try {
+            return await operation()
+        } catch (error) {
+            if (options.isRetryable(error) && attempt < options.maxAttempts) {
+                const delayMs = options.baseDelayMs * Math.pow(2, attempt - 1)
+                options.onRetry?.(attempt, delayMs, error)
+                await new Promise(resolve => setTimeout(resolve, delayMs))
             } else {
                 throw error
             }
         }
     }
+    // Unreachable: loop either returns on success or throws on failure.
+    throw new Error('retryWithBackoff: exhausted attempts')
 }
 
 function hasHttpStatus(error: unknown): error is Error & {status: number} {

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import {expect, test, jest} from '@jest/globals'
 
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
+import {determineGradleVersion} from '../../src/execution/gradle'
 
 jest.setTimeout(120000)
 
@@ -15,14 +16,20 @@ test('will cleanup unused dependency jars and build-cache entries', async () => 
     const cacheCleaner = new CacheCleaner(gradleUserHome, tmpDir)
 
     await runGradleBuild(projectRoot, 'build', '3.1')
-    
+
     const timestamp = await cacheCleaner.prepare()
 
     await runGradleBuild(projectRoot, 'build', '3.1.1')
 
-    const commonsMath31 = path.resolve(gradleUserHome, "caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1")
-    const commonsMath311 = path.resolve(gradleUserHome, "caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1.1")
-    const buildCacheDir = path.resolve(gradleUserHome, "caches/build-cache-1")
+    const commonsMath31 = path.resolve(
+        gradleUserHome,
+        'caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1'
+    )
+    const commonsMath311 = path.resolve(
+        gradleUserHome,
+        'caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1.1'
+    )
+    const buildCacheDir = path.resolve(gradleUserHome, 'caches/build-cache-1')
 
     expect(fs.existsSync(commonsMath31)).toBe(true)
     expect(fs.existsSync(commonsMath311)).toBe(true)
@@ -50,12 +57,14 @@ test('will cleanup unused gradle versions', async () => {
     // Run with only one of these versions
     await runGradleBuild(projectRoot, 'build')
 
-    const gradle802 = path.resolve(gradleUserHome, "caches/8.0.2")
-    const transforms3 = path.resolve(gradleUserHome, "caches/transforms-3")
-    const metadata100 = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.100")
-    const wrapper802 = path.resolve(gradleUserHome, "wrapper/dists/gradle-8.0.2-bin")
-    const gradleCurrent = path.resolve(gradleUserHome, "caches/8.14.2")
-    const metadataCurrent = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.107")
+    const gradle802 = path.resolve(gradleUserHome, 'caches/8.0.2')
+    const transforms3 = path.resolve(gradleUserHome, 'caches/transforms-3')
+    const metadata100 = path.resolve(gradleUserHome, 'caches/modules-2/metadata-2.100')
+    const wrapper802 = path.resolve(gradleUserHome, 'wrapper/dists/gradle-8.0.2-bin')
+    const currentGradleVersion = await determineGradleVersion('gradle')
+    expect(currentGradleVersion).toBeDefined()
+    const gradleCurrent = path.resolve(gradleUserHome, `caches/${currentGradleVersion}`)
+    const metadataCurrent = path.resolve(gradleUserHome, 'caches/modules-2/metadata-2.107')
 
     expect(fs.existsSync(gradle802)).toBe(true)
     expect(fs.existsSync(transforms3)).toBe(true)
@@ -95,10 +104,10 @@ async function runGradleWrapperBuild(projectRoot: string, args: string, version:
 
 function prepareTestProject(): string {
     const projectRoot = 'test/jest/resources/cache-cleanup'
-    fs.rmSync(path.resolve(projectRoot, 'HOME'), { recursive: true, force: true })
-    fs.rmSync(path.resolve(projectRoot, 'tmp'), { recursive: true, force: true })
-    fs.rmSync(path.resolve(projectRoot, 'build'), { recursive: true, force: true })
-    fs.rmSync(path.resolve(projectRoot, '.gradle'), { recursive: true, force: true })
+    fs.rmSync(path.resolve(projectRoot, 'HOME'), {recursive: true, force: true})
+    fs.rmSync(path.resolve(projectRoot, 'tmp'), {recursive: true, force: true})
+    fs.rmSync(path.resolve(projectRoot, 'build'), {recursive: true, force: true})
+    fs.rmSync(path.resolve(projectRoot, '.gradle'), {recursive: true, force: true})
     return projectRoot
 }
 

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import {expect, test, jest} from '@jest/globals'
 
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
+import {determineGradleVersion} from '../../src/execution/gradle'
 
 jest.setTimeout(120000)
 
@@ -54,7 +55,9 @@ test('will cleanup unused gradle versions', async () => {
     const transforms3 = path.resolve(gradleUserHome, "caches/transforms-3")
     const metadata100 = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.100")
     const wrapper802 = path.resolve(gradleUserHome, "wrapper/dists/gradle-8.0.2-bin")
-    const gradleCurrent = path.resolve(gradleUserHome, "caches/8.14.2")
+    const currentGradleVersion = await determineGradleVersion('gradle')
+    expect(currentGradleVersion).toBeDefined()
+    const gradleCurrent = path.resolve(gradleUserHome, `caches/${currentGradleVersion}`)
     const metadataCurrent = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.107")
 
     expect(fs.existsSync(gradle802)).toBe(true)

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import {expect, test, jest} from '@jest/globals'
 
 import {CacheCleaner} from '../../src/caching/cache-cleaner'
-import {determineGradleVersion} from '../../src/execution/gradle'
 
 jest.setTimeout(120000)
 
@@ -16,20 +15,14 @@ test('will cleanup unused dependency jars and build-cache entries', async () => 
     const cacheCleaner = new CacheCleaner(gradleUserHome, tmpDir)
 
     await runGradleBuild(projectRoot, 'build', '3.1')
-
+    
     const timestamp = await cacheCleaner.prepare()
 
     await runGradleBuild(projectRoot, 'build', '3.1.1')
 
-    const commonsMath31 = path.resolve(
-        gradleUserHome,
-        'caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1'
-    )
-    const commonsMath311 = path.resolve(
-        gradleUserHome,
-        'caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1.1'
-    )
-    const buildCacheDir = path.resolve(gradleUserHome, 'caches/build-cache-1')
+    const commonsMath31 = path.resolve(gradleUserHome, "caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1")
+    const commonsMath311 = path.resolve(gradleUserHome, "caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.1.1")
+    const buildCacheDir = path.resolve(gradleUserHome, "caches/build-cache-1")
 
     expect(fs.existsSync(commonsMath31)).toBe(true)
     expect(fs.existsSync(commonsMath311)).toBe(true)
@@ -57,14 +50,12 @@ test('will cleanup unused gradle versions', async () => {
     // Run with only one of these versions
     await runGradleBuild(projectRoot, 'build')
 
-    const gradle802 = path.resolve(gradleUserHome, 'caches/8.0.2')
-    const transforms3 = path.resolve(gradleUserHome, 'caches/transforms-3')
-    const metadata100 = path.resolve(gradleUserHome, 'caches/modules-2/metadata-2.100')
-    const wrapper802 = path.resolve(gradleUserHome, 'wrapper/dists/gradle-8.0.2-bin')
-    const currentGradleVersion = await determineGradleVersion('gradle')
-    expect(currentGradleVersion).toBeDefined()
-    const gradleCurrent = path.resolve(gradleUserHome, `caches/${currentGradleVersion}`)
-    const metadataCurrent = path.resolve(gradleUserHome, 'caches/modules-2/metadata-2.107')
+    const gradle802 = path.resolve(gradleUserHome, "caches/8.0.2")
+    const transforms3 = path.resolve(gradleUserHome, "caches/transforms-3")
+    const metadata100 = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.100")
+    const wrapper802 = path.resolve(gradleUserHome, "wrapper/dists/gradle-8.0.2-bin")
+    const gradleCurrent = path.resolve(gradleUserHome, "caches/8.14.2")
+    const metadataCurrent = path.resolve(gradleUserHome, "caches/modules-2/metadata-2.107")
 
     expect(fs.existsSync(gradle802)).toBe(true)
     expect(fs.existsSync(transforms3)).toBe(true)
@@ -104,10 +95,10 @@ async function runGradleWrapperBuild(projectRoot: string, args: string, version:
 
 function prepareTestProject(): string {
     const projectRoot = 'test/jest/resources/cache-cleanup'
-    fs.rmSync(path.resolve(projectRoot, 'HOME'), {recursive: true, force: true})
-    fs.rmSync(path.resolve(projectRoot, 'tmp'), {recursive: true, force: true})
-    fs.rmSync(path.resolve(projectRoot, 'build'), {recursive: true, force: true})
-    fs.rmSync(path.resolve(projectRoot, '.gradle'), {recursive: true, force: true})
+    fs.rmSync(path.resolve(projectRoot, 'HOME'), { recursive: true, force: true })
+    fs.rmSync(path.resolve(projectRoot, 'tmp'), { recursive: true, force: true })
+    fs.rmSync(path.resolve(projectRoot, 'build'), { recursive: true, force: true })
+    fs.rmSync(path.resolve(projectRoot, '.gradle'), { recursive: true, force: true })
     return projectRoot
 }
 

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -1,7 +1,7 @@
-import {describe, expect, it} from '@jest/globals'
+import {beforeEach, afterEach, describe, expect, it, jest} from '@jest/globals'
 
 import {DependencyGraphConfig} from "../../src/configuration" 
-import {isRetryableError, getErrorStatusText} from "../../src/dependency-graph"
+import {isRetryableError, getErrorStatusText, retryWithBackoff} from "../../src/dependency-graph"
 
 function httpError(status: number, message: string): Error & {status: number} {
     return Object.assign(new Error(message), {name: 'HttpError', status})
@@ -91,6 +91,87 @@ describe('dependency-graph', () => {
         it('returns empty string for non-Error values', () => {
             expect(getErrorStatusText('string')).toBe('')
             expect(getErrorStatusText(null)).toBe('')
+        })
+    })
+
+    describe('retryWithBackoff', () => {
+        const baseOptions = {
+            maxAttempts: 3,
+            baseDelayMs: 1000,
+            isRetryable: isRetryableError
+        }
+
+        beforeEach(() => {
+            jest.useFakeTimers()
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('returns the result on first success without delay', async () => {
+            const operation = jest.fn<() => Promise<string>>().mockResolvedValue('result')
+            const onRetry = jest.fn()
+
+            await expect(retryWithBackoff(operation, {...baseOptions, onRetry})).resolves.toBe('result')
+            expect(operation).toHaveBeenCalledTimes(1)
+            expect(onRetry).not.toHaveBeenCalled()
+        })
+
+        it('retries on a retryable error and returns the eventual result', async () => {
+            const operation = jest.fn<() => Promise<string>>()
+                .mockRejectedValueOnce(httpError(503, 'down'))
+                .mockResolvedValueOnce('ok')
+            const onRetry = jest.fn()
+
+            const promise = retryWithBackoff(operation, {...baseOptions, onRetry})
+            await jest.advanceTimersByTimeAsync(1000)
+
+            await expect(promise).resolves.toBe('ok')
+            expect(operation).toHaveBeenCalledTimes(2)
+            expect(onRetry).toHaveBeenCalledTimes(1)
+            expect(onRetry).toHaveBeenCalledWith(1, 1000, expect.any(Error))
+        })
+
+        it('uses exponential backoff between attempts', async () => {
+            const operation = jest.fn<() => Promise<string>>()
+                .mockRejectedValueOnce(httpError(500, 'fail'))
+                .mockRejectedValueOnce(httpError(500, 'fail'))
+                .mockResolvedValueOnce('ok')
+            const onRetry = jest.fn()
+
+            const promise = retryWithBackoff(operation, {...baseOptions, onRetry})
+            await jest.advanceTimersByTimeAsync(1000) // first retry delay
+            await jest.advanceTimersByTimeAsync(2000) // second retry delay
+
+            await expect(promise).resolves.toBe('ok')
+            expect(operation).toHaveBeenCalledTimes(3)
+            expect(onRetry).toHaveBeenNthCalledWith(1, 1, 1000, expect.any(Error))
+            expect(onRetry).toHaveBeenNthCalledWith(2, 2, 2000, expect.any(Error))
+        })
+
+        it('throws the last error after exhausting maxAttempts', async () => {
+            const error = httpError(503, 'still down')
+            const operation = jest.fn<() => Promise<string>>().mockRejectedValue(error)
+            const onRetry = jest.fn()
+
+            await Promise.all([
+                expect(retryWithBackoff(operation, {...baseOptions, onRetry})).rejects.toBe(error),
+                jest.advanceTimersByTimeAsync(3000) // 1000 + 2000
+            ])
+
+            expect(operation).toHaveBeenCalledTimes(3)
+            expect(onRetry).toHaveBeenCalledTimes(2)
+        })
+
+        it('throws immediately on a non-retryable error', async () => {
+            const error = httpError(404, 'not found')
+            const operation = jest.fn<() => Promise<string>>().mockRejectedValue(error)
+            const onRetry = jest.fn()
+
+            await expect(retryWithBackoff(operation, {...baseOptions, onRetry})).rejects.toBe(error)
+            expect(operation).toHaveBeenCalledTimes(1)
+            expect(onRetry).not.toHaveBeenCalled()
         })
     })
 })

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, afterEach, describe, expect, it, jest} from '@jest/globals'
 
-import {DependencyGraphConfig} from "../../src/configuration" 
-import {isRetryableError, getErrorStatusText, retryWithBackoff} from "../../src/dependency-graph"
+import {DependencyGraphConfig} from '../../src/configuration' 
+import {isRetryableError, getErrorStatusText, retryWithBackoff} from '../../src/dependency-graph'
 
 function httpError(status: number, message: string): Error & {status: number} {
     return Object.assign(new Error(message), {name: 'HttpError', status})

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -3,6 +3,10 @@ import {describe, expect, it} from '@jest/globals'
 import {DependencyGraphConfig} from "../../src/configuration" 
 import {isRetryableError, getErrorStatusText} from "../../src/dependency-graph"
 
+function httpError(status: number, message: string): Error & {status: number} {
+    return Object.assign(new Error(message), {name: 'HttpError', status})
+}
+
 describe('dependency-graph', () => {
     describe('constructs job correlator', () => {
         it('removes commas from workflow name', () => {
@@ -36,13 +40,6 @@ describe('dependency-graph', () => {
     })
 
     describe('isRetryableError', () => {
-        function httpError(status: number, message: string): Error {
-            const error = new Error(message)
-            error.name = 'HttpError'
-            ;(error as Error & {status: number}).status = status
-            return error
-        }
-
         it('returns true for HTTP 429 (rate limit)', () => {
             expect(isRetryableError(httpError(429, 'rate limit exceeded'))).toBe(true)
         })
@@ -84,9 +81,7 @@ describe('dependency-graph', () => {
 
     describe('getErrorStatusText', () => {
         it('returns status text for HttpError with status', () => {
-            const error = new Error('Server Error')
-            ;(error as Error & {status: number}).status = 503
-            expect(getErrorStatusText(error)).toBe(' (HTTP 503)')
+            expect(getErrorStatusText(httpError(503, 'Server Error'))).toBe(' (HTTP 503)')
         })
 
         it('returns empty string for plain Error without status', () => {

--- a/sources/test/jest/dependency-graph.test.ts
+++ b/sources/test/jest/dependency-graph.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from '@jest/globals'
 
 import {DependencyGraphConfig} from "../../src/configuration" 
+import {isRetryableError, getErrorStatusText} from "../../src/dependency-graph"
 
 describe('dependency-graph', () => {
     describe('constructs job correlator', () => {
@@ -31,6 +32,70 @@ describe('dependency-graph', () => {
         it('with composite matrix value', () => {
             const id = DependencyGraphConfig.constructJobCorrelator('workflow', 'jobid', '{"os": "windows", "java-version": "21.1", "other": "Value, with COMMA"}')
             expect(id).toBe('workflow-jobid-windows-211-value_with_comma')
+        })
+    })
+
+    describe('isRetryableError', () => {
+        function httpError(status: number, message: string): Error {
+            const error = new Error(message)
+            error.name = 'HttpError'
+            ;(error as Error & {status: number}).status = status
+            return error
+        }
+
+        it('returns true for HTTP 429 (rate limit)', () => {
+            expect(isRetryableError(httpError(429, 'rate limit exceeded'))).toBe(true)
+        })
+
+        it('returns true for HTTP 500 (internal server error)', () => {
+            expect(isRetryableError(httpError(500, 'Internal Server Error'))).toBe(true)
+        })
+
+        it('returns true for HTTP 502 (bad gateway)', () => {
+            expect(isRetryableError(httpError(502, 'Bad Gateway'))).toBe(true)
+        })
+
+        it('returns true for HTTP 503 (service unavailable)', () => {
+            expect(isRetryableError(httpError(503, 'Service Unavailable'))).toBe(true)
+        })
+
+        it('returns false for HTTP 403 (forbidden)', () => {
+            expect(isRetryableError(httpError(403, 'Resource not accessible by integration'))).toBe(false)
+        })
+
+        it('returns false for HTTP 404 (not found)', () => {
+            expect(isRetryableError(httpError(404, 'Not Found'))).toBe(false)
+        })
+
+        it('returns false for HTTP 422 (unprocessable entity)', () => {
+            expect(isRetryableError(httpError(422, 'Validation Failed'))).toBe(false)
+        })
+
+        it('returns false for a plain Error without status', () => {
+            expect(isRetryableError(new Error('network error'))).toBe(false)
+        })
+
+        it('returns false for non-Error values', () => {
+            expect(isRetryableError('some string')).toBe(false)
+            expect(isRetryableError(null)).toBe(false)
+            expect(isRetryableError(undefined)).toBe(false)
+        })
+    })
+
+    describe('getErrorStatusText', () => {
+        it('returns status text for HttpError with status', () => {
+            const error = new Error('Server Error')
+            ;(error as Error & {status: number}).status = 503
+            expect(getErrorStatusText(error)).toBe(' (HTTP 503)')
+        })
+
+        it('returns empty string for plain Error without status', () => {
+            expect(getErrorStatusText(new Error('no status'))).toBe('')
+        })
+
+        it('returns empty string for non-Error values', () => {
+            expect(getErrorStatusText('string')).toBe('')
+            expect(getErrorStatusText(null)).toBe('')
         })
     })
 })


### PR DESCRIPTION
Fixes https://github.com/github/dependency-graph/issues/10048.

The dependency graph submission to GitHub's Dependency Submission API had no retry logic, causing intermittent HttpError failures that succeed on manual re-run. This adds:

- Retry loop with exponential backoff (3 attempts: 1s, 2s, 4s delays) for transient errors (HTTP 429, 5xx)
- Non-retryable errors (4xx except 429) fail immediately
- HTTP status code included in error messages for better diagnostics
- Unit tests for retry classification and error status helpers